### PR TITLE
Fix Dockerfile for php-fpm container.

### DIFF
--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7-fpm
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get install -y git zlib1g-dev zip unzip
+RUN apt-get update && apt-get install -y git zlib1g-dev zip unzip libzip-dev
 RUN docker-php-ext-install zip
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer


### PR DESCRIPTION
Fixed Dockerfile for php-fpm container because output this error when execute `docker-compose up --build`command.
```shell
ERROR: Service 'php-fpm' failed to build: The command '/bin/sh -c docker-php-ext-install zip' returned a non-zero code: 1
```

### OS Version
```shell
$ sw_vers
ProductName:    Mac OS X
ProductVersion: 10.13.4
BuildVersion:   17E199
```

### Docker Version
```shell
$ docker version
Client: Docker Engine - Community
 Version:           19.03.1
 API version:       1.40
 Go version:        go1.12.5
 Git commit:        74b1e89
 Built:             Thu Jul 25 21:18:17 2019
 OS/Arch:           darwin/amd64
 Experimental:      false

Server: Docker Engine - Community
 Engine:
  Version:          19.03.1
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.12.5
  Git commit:       74b1e89
  Built:            Thu Jul 25 21:17:52 2019
  OS/Arch:          linux/amd64
  Experimental:     true
 containerd:
  Version:          v1.2.6
  GitCommit:        894b81a4b802e4eb2a91d1ce216b8817763c29fb
 runc:
  Version:          1.0.0-rc8
  GitCommit:        425e105d5a03fabd737a126ad93d62a9eeede87f
 docker-init:
  Version:          0.18.0
  GitCommit:        fec3683
```

### Error Output

```shell
$ docker-compose up --build
Creating network "laravel-ecs-demo_default" with the default driver
Building php-fpm
Step 1/13 : FROM php:7-fpm
 ---> 888cc7ac7127
Step 2/13 : ENV DEBIAN_FRONTEND noninteractive
 ---> Using cache
 ---> 9397a86413b7
Step 3/13 : RUN apt-get update && apt-get install -y git zlib1g-dev zip unzip
 ---> Using cache
 ---> 3171bc3e13ba
Step 4/13 : RUN docker-php-ext-install zip
 ---> Running in 885d3151c2cf
Configuring for:
PHP Api Version:         20180731
Zend Module Api No:      20180731
Zend Extension Api No:   320180731
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for a sed that does not truncate output... /bin/sed
checking for cc... cc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether cc accepts -g... yes
checking for cc option to accept ISO C89... none needed
checking how to run the C preprocessor... cc -E
checking for icc... no
checking for suncc... no
checking whether cc understands -c and -o together... yes
checking for system library directory... lib
checking if compiler supports -R... no
checking if compiler supports -Wl,-rpath,... yes
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking target system type... x86_64-pc-linux-gnu
checking for PHP prefix... /usr/local
checking for PHP includes... -I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/TSRM -I/usr/local/include/php/Zend -I/usr/local/include/php/ext -I/usr/local/include/php/ext/date/lib
checking for PHP extension directory... /usr/local/lib/php/extensions/no-debug-non-zts-20180731
checking for PHP installed headers prefix... /usr/local/include/php
checking if debug is enabled... no
checking if zts is enabled... no
checking for re2c... re2c
checking for re2c version... 1.1.1 (ok)
checking for gawk... no
checking for nawk... nawk
checking if nawk is broken... no
checking for zip archive read/writesupport... yes, shared
checking for the location of libz... no
checking pcre install prefix... no
checking libzip... yes
checking for the location of zlib... /usr
checking for pkg-config... /usr/bin/pkg-config
checking for libzip... not found
configure: error: Please reinstall the libzip distribution
ERROR: Service 'php-fpm' failed to build: The command '/bin/sh -c docker-php-ext-install zip' returned a non-zero code: 1
```

It was confirmed that the error would be resolved when building after this fix.